### PR TITLE
copy-multipart-object

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-aws-s3 "0.3.10"
+(defproject clj-aws-s3 "0.3.11"
   :description "Clojure Amazon S3 library"
   :url "https://github.com/weavejester/clj-aws-s3"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Adds ``copy-multipart-object`` function, which copies large files in parallel.  Functions similarly to ``put-mutlpart-object``, but is passed a source bucket and key instead of a file.

https://collectiveds.atlassian.net/browse/BE-580

/cc @mikeflynn 