### PR TITLE
fix multipart-copy part size bug

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -482,7 +482,10 @@
        (.setUploadId upload-id)
        (.setPartNumber (+ 1 (/ offset part-size)))
        (.setFirstByte (long offset))
-       (.setLastByte (long (min (+ part-size offset) (dec file-size))))))))
+       (.setLastByte (long
+                       (min
+                         (dec (+ part-size offset))
+                         (dec file-size))))))))
 
 (defn copy-multipart-object
   "Do a multipart copy of a file from an S3 bucket at the specified source key


### PR DESCRIPTION
Fix a bug with the ``lastByte`` field of a copy part from a ``copy-multipart-object`` request.  Each part was one byte too long, which repeated the last byte of each part, corrupting the file.

https://collectiveds.atlassian.net/browse/BE-616

/cc @mikeflynn