### PR TITLE
[BE-664] Issues with YouTube Reports Job

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [com.amazonaws/aws-java-sdk "1.7.5"]
+                 [com.amazonaws/aws-java-sdk "1.9.40"]
                  [clj-time "0.6.0"]]
   :plugins [[codox "0.8.10"]])


### PR DESCRIPTION
The error seems to be related to a bug with buffering a ``FileInputStream`` while writing to S3.  The bug was [fixed in aws-java-sdk 1.9.34](https://github.com/aws/aws-sdk-java/issues/427#issuecomment-100581879), but our version of ``clj-aws-s3`` uses ``1.7.5`` .  This commit bumps that to ``1.9.40`` (latest release compatible with ``clj-aws-s3``), which should hopefully fix this error.

https://collectiveds.atlassian.net/browse/BE-664

/cc @mikeflynn 