### PR TITLE
[BE-760] Pipeline / API Dependency Update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject clj-aws-s3 "0.3.11"
+(defproject clj-aws-s3 "0.3.12"
   :description "Clojure Amazon S3 library"
   :url "https://github.com/weavejester/clj-aws-s3"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.2.1"]
-                 [com.amazonaws/aws-java-sdk "1.9.40" :exclusions [joda-time]]
-                 [clj-time "0.6.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.amazonaws/aws-java-sdk "1.11.130"]
+                 [clj-time "0.13.0"]]
   :plugins [[codox "0.8.10"]])


### PR DESCRIPTION
Bumps ``clj-http``, ``clj-time``, ``cheshire``, and ``simple-time`` to their latest versions and updates exclusions.  Bumps clojure to ``1.8.0``.

https://collectiveds.atlassian.net/browse/BE-760

/cc @mikeflynn 