### PR TITLE
[BE-2630] Unable to read Megaphone reports from PROD

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -61,7 +61,7 @@
         (AmazonS3ClientBuilder/standard)
         (AWSStaticCredentialsProvider.
           (BasicAWSCredentials. (:access-key cred) (:secret-key cred))))
-      "us-east-1")))
+      (or (:region cred) "us-east-1"))))
 
 (def ^{:private true :tag AmazonS3Client}
   s3-client


### PR DESCRIPTION
Updates `s3-client*` to accept an optional `:region` field in the AWS credentials.  Defaults to `us-east-1` as currently if none supplied.

https://collectiveds.atlassian.net/browse/BE-2630
Relates to https://github.com/CollectiveDS/cdshub/pull/1479

/cc @mikeflynn 