### PR TITLE
upgrade clojure.core to 1.10.1, aws.java.sdk to 1.12.441

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/weavejester/clj-aws-s3"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.amazonaws/aws-java-sdk "1.11.130"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [com.amazonaws/aws-java-sdk "1.12.441"]
                  [clj-time "0.13.0"]]
   :plugins [[codox "0.8.10"]])


### PR DESCRIPTION
Updates `project.clj` to bump the following dependency versions:
```
org.clojure/clojure  1.8.0 -> 1.10.1
com.amazonaws/aws-java.sdk 1.11.130 -> 1.12.441
```

https://collectiveds.atlassian.net/browse/BE-3895

/cc @mikeflynn @Krayzel 